### PR TITLE
Fix typos and rename template config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm create purista
 bun create purista
 ```
 
-**OR with pnpm**
+**OR with Yarn**
 
 ```sh
 yarn create purista

--- a/src/copyFileFromRepo.ts
+++ b/src/copyFileFromRepo.ts
@@ -3,7 +3,7 @@ import path, { join } from 'node:path'
 
 import { rewriteLocalImportPaths } from './convertString.js'
 import { type PKG, writePackageJson } from './getPackageJson.js'
-import { templateConig } from './templateConig.js'
+import { templateConfig } from './templateConfig.js'
 import type { Settings } from './types.js'
 
 export const copyFileFromRepo = async (
@@ -12,7 +12,7 @@ export const copyFileFromRepo = async (
 	sourcePath: string,
 	destination: string,
 ) => {
-	const url = `https://raw.githubusercontent.com/${templateConig.user}/${templateConig.repository}/${templateConig.ref}/${sourcePath}`
+	const url = `https://raw.githubusercontent.com/${templateConfig.user}/${templateConfig.repository}/${templateConfig.ref}/${sourcePath}`
 	const resp = await fetch(url)
 	if (!resp.ok) {
 		console.error(`Unable to load ${sourcePath}`)

--- a/src/createDaprBridge.ts
+++ b/src/createDaprBridge.ts
@@ -4,11 +4,11 @@ import { createSpinner } from 'nanospinner'
 import tiged from 'tiged'
 import { convertFilename } from './convertString.js'
 import { copyFileFromRepo } from './copyFileFromRepo.js'
-import { templateConig } from './templateConig.js'
+import { templateConfig } from './templateConfig.js'
 import type { Settings } from './types.js'
 import { walkAndRename } from './walkAndRename.js'
 
-const getRepoContentUrl = `https://api.github.com/repos/${templateConig.user}/${templateConig.repository}/git/trees/${templateConig.ref}?recursive=true`
+const getRepoContentUrl = `https://api.github.com/repos/${templateConfig.user}/${templateConfig.repository}/git/trees/${templateConfig.ref}?recursive=true`
 
 export const createDaprBridge = async (targetDirectoryPath: string, settings: Settings) => {
 	const templateName = 'dapr'
@@ -16,7 +16,7 @@ export const createDaprBridge = async (targetDirectoryPath: string, settings: Se
 
 	await new Promise((resolve, reject) => {
 		const emitter = tiged(
-			`${templateConig.user}/${templateConig.repository}/${templateConig.directory}/${templateName}#${templateConig.ref}`,
+			`${templateConfig.user}/${templateConfig.repository}/${templateConfig.directory}/${templateName}#${templateConfig.ref}`,
 			{
 				cache: false,
 				force: true,
@@ -45,12 +45,12 @@ export const createDaprBridge = async (targetDirectoryPath: string, settings: Se
 
 	const getFilesFromRepo = async (subPath: string) => {
 		const eventBridgeFiles = fileListAll.tree
-			.filter(entry => entry.path.startsWith(`${templateConig.directory}/${subPath}`) && entry.type === 'blob')
+			.filter(entry => entry.path.startsWith(`${templateConfig.directory}/${subPath}`) && entry.type === 'blob')
 			.map(e => {
 				const p = e.path
 					.split('/') // split the path
 					.slice(subPath.split('/').length + 1) // remove prefix-folders
-					.map(n => convertFilename(settings, n)) // convert to prefered casing
+                                       .map(n => convertFilename(settings, n)) // convert to preferred casing
 				return copyFileFromRepo(settings, targetDirectoryPath, e.path, join(...p))
 			})
 

--- a/src/createRegularBridges.ts
+++ b/src/createRegularBridges.ts
@@ -4,11 +4,11 @@ import { createSpinner } from 'nanospinner'
 import tiged from 'tiged'
 import { convertFilename } from './convertString.js'
 import { copyFileFromRepo } from './copyFileFromRepo.js'
-import { templateConig } from './templateConig.js'
+import { templateConfig } from './templateConfig.js'
 import type { Settings } from './types.js'
 import { walkAndRename } from './walkAndRename.js'
 
-const getRepoContentUrl = `https://api.github.com/repos/${templateConig.user}/${templateConig.repository}/git/trees/${templateConig.ref}?recursive=true`
+const getRepoContentUrl = `https://api.github.com/repos/${templateConfig.user}/${templateConfig.repository}/git/trees/${templateConfig.ref}?recursive=true`
 
 export const createRegularBridges = async (targetDirectoryPath: string, settings: Settings) => {
 	const templateName = settings.eventBridge === 'dapr' ? 'dapr' : 'base'
@@ -17,7 +17,7 @@ export const createRegularBridges = async (targetDirectoryPath: string, settings
 
 	await new Promise((resolve, reject) => {
 		const emitter = tiged(
-			`${templateConig.user}/${templateConig.repository}/${templateConig.directory}/${templateName}#${templateConig.ref}`,
+			`${templateConfig.user}/${templateConfig.repository}/${templateConfig.directory}/${templateName}#${templateConfig.ref}`,
 			{
 				cache: false,
 				force: true,
@@ -46,12 +46,12 @@ export const createRegularBridges = async (targetDirectoryPath: string, settings
 
 	const getFilesFromRepo = async (subPath: string) => {
 		const eventBridgeFiles = fileListAll.tree
-			.filter(entry => entry.path.startsWith(`${templateConig.directory}/${subPath}`) && entry.type === 'blob')
+			.filter(entry => entry.path.startsWith(`${templateConfig.directory}/${subPath}`) && entry.type === 'blob')
 			.map(e => {
 				const p = e.path
 					.split('/') // split the path
 					.slice(subPath.split('/').length + 1) // remove prefix-folders
-					.map(n => convertFilename(settings, n)) // convert to prefered casing
+                                       .map(n => convertFilename(settings, n)) // convert to preferred casing
 				return copyFileFromRepo(settings, targetDirectoryPath, e.path, join(...p))
 			})
 

--- a/src/getSettings.ts
+++ b/src/getSettings.ts
@@ -33,7 +33,7 @@ const bridges = [
 	{ value: 'dapr', name: 'Dapr', description: 'Dapr Runtime' },
 ]
 
-const fileConvetions = [
+const fileConventions = [
 	{
 		value: 'camel',
 		name: 'camel case',
@@ -61,7 +61,7 @@ const fileConvetions = [
 	},
 ]
 
-const eventConvetions = [
+const eventConventions = [
 	{
 		value: 'camel',
 		name: 'camel case',
@@ -92,11 +92,11 @@ const eventConvetions = [
 		name: 'constant case',
 		description: 'MY_EVENT',
 	},
-	{
-		value: 'constantCase',
-		name: 'dot case',
-		description: 'my.event',
-	},
+       {
+               value: 'dotCase',
+               name: 'dot case',
+               description: 'my.event',
+       },
 	{
 		value: 'pathCase',
 		name: 'path case',
@@ -122,7 +122,7 @@ const linters = [
 	},
 	{
 		value: 'none',
-		name: 'DO not install a linter',
+               name: 'Do not install a linter',
 		description: 'https://eslint.org/',
 	},
 ]
@@ -231,7 +231,7 @@ export const getSettings = async (args: Arguments) => {
 		(await select({
 			loop: true,
 			message: 'Which file naming convention do you prefer?',
-			choices: fileConvetions,
+			choices: fileConventions,
 			default: 0,
 		}))
 
@@ -240,7 +240,7 @@ export const getSettings = async (args: Arguments) => {
 		(await select({
 			loop: true,
 			message: 'Which naming convention should be used for events?',
-			choices: eventConvetions,
+			choices: eventConventions,
 			default: 0,
 		}))
 

--- a/src/templateConfig.ts
+++ b/src/templateConfig.ts
@@ -1,4 +1,4 @@
-export const templateConig = {
+export const templateConfig = {
 	directory: 'templates',
 	repository: 'starter',
 	user: 'puristajs',

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ export type Settings = {
 	useWebserver: boolean
 	/** Format convention for files (camel case, snake case...) */
 	fileConvention: 'camel' | 'snake' | 'kebab' | 'pascal' | 'pascalSnake'
-	/** Format convetion to use for events (snake case, camel case...) */
+       /** Format convention to use for events (snake case, camel case...) */
 	eventConvention:
 		| 'camel'
 		| 'snake'


### PR DESCRIPTION
## Summary
- fix README instructions
- rename templateConig to templateConfig
- fix typos in regular and Dapr bridge code
- fix event conventions and linter wording

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'node')*
- `npm test`
- `npm run lint` *(fails: bunx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68568f9c04348328bc0bfcc781f5c646