### PR TITLE
[codex] Recommend PURISTA AI skill after init

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,15 @@ import { parseArgs } from './parseArgs.js'
 
 const stringArg = <T extends string>(value: unknown) => (typeof value === 'string' ? (value as T) : undefined)
 
+function renderSkillRecommendation() {
+	console.log('\nRecommended for AI-assisted development:')
+	console.log('  npx skills add puristajs/purista --skill purista')
+	console.log(
+		'This installs the PURISTA AI skill so coding assistants understand services, builders, command contracts, and runtime wiring.',
+	)
+	console.log('Docs: https://purista.dev/handbook/install-ai-skill/')
+}
+
 async function main() {
 	const args = parseArgs(process.argv.slice(2))
 	const mode = getCommandMode({
@@ -65,6 +74,7 @@ async function main() {
 		const result = await initProjectCommand.execute(resolution.resolvedInput, context)
 
 		output.renderResult(result)
+		renderSkillRecommendation()
 	} catch (error) {
 		output.renderError(error)
 		process.exit(error instanceof PuristaCliError ? error.exitCode : 1)


### PR DESCRIPTION
## Summary

Adds a post-init recommendation to `create-purista` so new projects surface the PURISTA AI skill install command immediately after scaffolding succeeds.

The message points users to:

```bash
npx skills add puristajs/purista --skill purista
```

and links to the new handbook install guide.

## Validation

- `./node_modules/.bin/tsc --noEmit` passes.
- `./node_modules/.bin/biome check src/index.ts` passes.
- `node build.ts && chmod +x ./bin.js` regenerated the bundled CLI.
- Smoke-tested `node bin.js <tmp>/demo-app --non-interactive --defaults --no-install`; the recommendation prints after project creation.

## Notes

`bun` is not installed in this shell, so I could not run `bun test` or `bun run build` directly. I ran the underlying local tools instead.