### PR TITLE
[codex] Report built-in agent guidance after init

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,12 +11,9 @@ import { parseArgs } from './parseArgs.js'
 const stringArg = <T extends string>(value: unknown) => (typeof value === 'string' ? (value as T) : undefined)
 
 function renderSkillRecommendation() {
-	console.log('\nRecommended for AI-assisted development:')
-	console.log('  npx skills add puristajs/purista --skill purista')
-	console.log(
-		'This installs the PURISTA AI skill so coding assistants understand services, builders, command contracts, and runtime wiring.',
-	)
-	console.log('Docs: https://purista.dev/handbook/install-ai-skill/')
+	console.log('\nAI-assisted development:')
+	console.log('  This project includes AGENTS.md, CLAUDE.md, .agents/IMPLEMENTATION.md, and local PURISTA skill links.')
+	console.log('  The skill links target node_modules/@purista/core/skills/purista and update with @purista/core.')
 }
 
 async function main() {


### PR DESCRIPTION
## Summary

- update the post-create message to explain that agent guidance and PURISTA skill links are generated by default
- rebuild `bin.js` from the updated source

## Validation

- `bun run build`
- `git diff --check`

## Related

Companion PURISTA CLI/docs PR: puristajs/purista#306