### PR TITLE
[codex] update create-purista tooling dependencies

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,11 +1,11 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
 	"assist": { "actions": { "source": { "organizeImports": "on" } } },
 	"files": { "includes": ["**", "!**/bin.js"] },
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true,
+			"preset": "recommended",
 			"suspicious": {
 				"noConsole": "off"
 			},

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
 		"test": "bun test"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.4.16",
+		"@biomejs/biome": "^2.5.2",
 		"@types/bun": "^1.3.14",
-		"@types/node": "^25.9.1",
-		"esbuild": "^0.28.0",
+		"@types/node": "^26.1.0",
+		"esbuild": "^0.28.1",
 		"typescript": "^6.0.3"
 	},
 	"license": "MIT",


### PR DESCRIPTION
## Summary
- Update create-purista tooling dependencies and Biome config for the current dependency pass.
- Rebuild the bundled bin.js output from the updated package metadata.

## Validation
- npm outdated --json -> {}
- npm run build

## Notes
- npm audit cannot run in this repo because there is no npm lockfile; bun audit was attempted but hung and was stopped.
